### PR TITLE
removing duplicate summary

### DIFF
--- a/pismo.gemspec
+++ b/pismo.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |s|
   s.authors     = ["Peter Cooper"]
   s.email       = ["git@peterc.org"]
   s.homepage    = "http://github.com/peterc/pismo"
-  s.summary     = %q{TODO: Write a gem summary}
   s.description = %q{Pismo extracts and retrieves content-related metadata from HTML pages - you can use the resulting data in an organized way, such as a summary/first paragraph, body text, keywords, RSS feed URL, favicon, etc.}
   s.summary     = %q{Extracts or retrieves content-related metadata from HTML pages}
   s.date        = %q{2010-12-19}


### PR DESCRIPTION
Hi Peter,

while watching rubyreloaded I saw that the summary is defined twice in the gemspec file.

Cheers

Chris
