### PR TITLE
shoulda should be a development dependency

### DIFF
--- a/pismo.gemspec
+++ b/pismo.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
   
-  s.add_dependency(%q<shoulda>, [">= 0"])
+  s.add_development_dependency(%q<shoulda>, [">= 0"])
   s.add_dependency(%q<awesome_print>, [">= 0"])
   s.add_dependency(%q<nokogiri>, [">= 0"])
   s.add_dependency(%q<sanitize>, [">= 0"])


### PR DESCRIPTION
Moved shoulda to be a development dependency so it's not included in release bundles.
