### PR TITLE
Content encoding fix

### DIFF
--- a/lib/pismo/reader/base.rb
+++ b/lib/pismo/reader/base.rb
@@ -49,9 +49,20 @@ module Pismo
       end
 
       def handle_content_encoding
+        # Ruby version is greater than 1.9, so use the native
+        # String.encoding method of handling unicode
+        # TODO: Handle < 1.9 with Iconv --  Wed Feb 29 15:24:18 2012
         if RUBY_VERSION > "1.9"
-          @raw_content.encode!("UTF-8", :invalid => :replace, :replace => '?') if @raw_content.encoding != "UTF-8"
-          @raw_content.encode!("ASCII-8BIT", :invalid => :replace, :replace => '?') if !@raw_content.valid_encoding?
+          # If the raw content is marked as UTF-8 and is not valid,
+          # clean it up by replacing invalidly encoded chars with '?',
+          # otherwise if the encoding is not UTF-8, try to force the
+          # conversion and if that fails try to force the content into ASCII-8BIT
+          if @raw_content.encoding == 'UTF-8' && @raw_content.valid_encoding? == false
+            @raw_content.encode!("UTF-8", :invalid => :replace, :undef => :replace, :replace => '?')
+          elsif @raw_content.encoding != 'UTF-8'
+            @raw_content.encode!("UTF-8", :invalid => :replace, :replace => '?')
+            @raw_content.encode!("ASCII-8BIT", :invalid => :replace, :undef => :replace, :replace => '?') if !@raw_content.valid_encoding?
+          end
         end
       end
 

--- a/lib/pismo/reader/base.rb
+++ b/lib/pismo/reader/base.rb
@@ -40,18 +40,24 @@ module Pismo
       # Create a document object based on the raw HTML content provided
       def initialize(raw_content, options = {})
         @options = options
-        @raw_content = Pismo::Document.clean_html(raw_content)
+        @raw_content = raw_content
+
+        handle_content_encoding
+        @raw_content = Pismo::Document.clean_html(@raw_content)
+
         build_doc
       end
 
-      def build_doc
-        @content = {}
-        
+      def handle_content_encoding
         if RUBY_VERSION > "1.9"
           @raw_content.encode!("UTF-8", :invalid => :replace, :replace => '?') if @raw_content.encoding != "UTF-8"
           @raw_content.encode!("ASCII-8BIT", :invalid => :replace, :replace => '?') if !@raw_content.valid_encoding?
         end
-  
+      end
+
+      def build_doc
+        @content = {}
+
         # Normalize whitespace (as much to make debugging sessions look nice as anything else)
         @raw_content.gsub!(/\s{2,}/, ' ')
         @raw_content.gsub!(/\r/, "\n")


### PR DESCRIPTION
There was a straightforward bug in the way the reader/base class handles the raw HTML content. The existing unicode conversion code was being called after the initial call to Pismo::Document.clean_html, which was causing the gsub! calls in clean_html to choke on some bad html. I just moved the call order around a little and wrote some additional logic to handle another corner case that cropped up.

I also pulled in the pull requests made by @bborn and @ashleyw, but my fixes don't depend on those so you should be able to isolate my commits if you want to just pull those in.
