### PR TITLE
Set explicit timezone during testing

### DIFF
--- a/test/corpus/metadata_expected.yaml
+++ b/test/corpus/metadata_expected.yaml
@@ -69,4 +69,4 @@
   :title: 18 Incredible CSS3 Effects You Have Never Seen Before
   :lede: "CSS3 is hot these days and will soon be available in most modern browser. Just recently, I started to become aware to the present of CSS3 around the web. I can see some of the websites such as twitter and designer portfolios websites are using it. Also, I have started to implement it to my own project as well and I really love it!"
   :sentences: CSS3 is hot these days and will soon be available in most modern browser. Just recently, I started to become aware to the present of CSS3 around the web. I can see some of the websites such as twitter and designer portfolios websites are using it.
-  :datetime: 2010-06-02 12:00:00 +01:00
+  :datetime: 2010-06-02 12:00:00 +00:00

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -9,6 +9,9 @@ $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
 require 'pismo'
 
+# Set time zone to prevent parsed times not matching those stored in metadata_expected.yaml
+ENV['TZ'] = 'UTC'
+
 class Test::Unit::TestCase
   include Pismo
   HTML_DIRECTORY = File.dirname(__FILE__) + "/corpus"


### PR DESCRIPTION
The metadata_expected.yaml includes datetimes with a +01:00 time zone. Which
means the test will fail for anybody running the test in a different time zone.
Explicitly setting the time zone to UTC in the helper solves this problem.
