### PR TITLE
New Pismo::Document#tags method.

### DIFF
--- a/lib/pismo/internal_attributes.rb
+++ b/lib/pismo/internal_attributes.rb
@@ -232,8 +232,38 @@ module Pismo
     def images(limit = 3)
       reader_doc && !reader_doc.images.empty? ? reader_doc.images(limit) : nil
     end
-    
-    # Returns the "keywords" in the document (not the meta keywords - they're next to useless now)
+
+    # Returns the tags or categories of the page/content
+    def tags
+      css_selectors = [
+                       '.watch-info-tag-list a',  # YouTube
+                       '.entry .tags a',          # Livejournal
+                       'a[rel~=tag]',             # Wordpress and many others
+                       'a.tag',                   # Tumblr
+                       '.tags a',
+                       '.labels a',
+                       '.categories a',
+                       '.topics a'
+                      ]
+
+      tags = []
+
+      # grab the first one we get results from
+      css_selectors.each do |css_selector|
+        tags += @doc.css(css_selector)
+        break if tags.any?
+      end
+
+      # convert from Nokogiri Element objects to strings
+      tags.map!(&:inner_text)
+
+      # remove "#" from hashtag-like tags
+      tags.map! { |t| t.gsub(/^#/, '') }
+
+      tags
+    end
+
+    # Returns the "keywords" in the document (not the meta 'ss'keywords - they're next to useless now)
     def keywords(options = {})
       options = { :stem_at => 20, :word_length_limit => 15, :limit => 20, :remove_stopwords => true, :minimum_score => 2 }.merge(options)
       

--- a/test/corpus/metadata_expected.yaml
+++ b/test/corpus/metadata_expected.yaml
@@ -5,7 +5,8 @@
   :lede: I'm just aching to know if the new Apple tablet (insert caveats, weasel words and qualifiers here) is a potential Cintiq competitor. I don't think it will be, but you never know. It may also have a built in barometer and bird call generator. I'm never sure if Apple does themselves more good than harm with the secrecy and anticipation that surrounds the run-up to these announcements.
   :feeds:
     - http://www.readwriteweb.com/rss.xml
-    - http://www.readwriteweb.com/archives/2010/01/cartoon_apple_tablet_now_with_barometer_and_bird_c.xml  
+    - http://www.readwriteweb.com/archives/2010/01/cartoon_apple_tablet_now_with_barometer_and_bird_c.xml 
+  :tags: [apple tablet, steve jobs] 
 :briancray: 
   :title: 5 great examples of popular blog posts that you should know
   :feed: http://feeds.feedburner.com/briancray/blog
@@ -54,6 +55,7 @@
   :author: Peter Cooper
   :lede: CoffeeScript (GitHub repo) is a new programming language with a pure Ruby compiler.
   :feed: http://www.rubyinside.com/feed/
+  :tags: [Cool]
 :zefrank:
   :sentences: If there's anyone who knows how to marshal an online audience, it's Ze Frank. Ze is best-known for his 2006 program "The Show," in which he made a new 2-3 minute video every day for 1 year. Topics ranged from "fingers in food" to the mysteries of airport signage to a tour de force summary of creatives' addiction to un-executed ideas, aka brain crack.
   :title: "Ze Frank on Imaginary Audiences :: Articles :: The 99 Percent"
@@ -73,3 +75,4 @@
 :thegoodbookblog:
   :title: Signs Of Life
   :datetime: 2012-07-25 12:00:00 +00:00
+  :tags: [Church Life, Marriage and Family, Ministry and Leadership]


### PR DESCRIPTION
Support extracting tags from documents.
