### PR TITLE
Close the stream by open-uri

### DIFF
--- a/lib/pismo/document.rb
+++ b/lib/pismo/document.rb
@@ -35,7 +35,7 @@ module Pismo
       @url = handle if handle =~ /\Ahttp/i
 
       @html = if handle =~ /\Ahttp/i
-                open(handle).read
+                open(handle) { |f| f.read }
               elsif handle.is_a?(StringIO) || handle.is_a?(IO) || handle.is_a?(Tempfile)
                 handle.read
               else


### PR DESCRIPTION
When pismo using in daemon it does not close opened stream which can see run lsof -p DAEMON_PID

After some hours of working – hundreads does not closed streams with CLOSE_WAIT status 

Source: https://github.com/ruby/ruby/blob/trunk/lib/open-uri.rb#L151
