### PR TITLE
Fix datetime detection on thegoodbookblog format

### DIFF
--- a/lib/pismo/internal_attributes.rb
+++ b/lib/pismo/internal_attributes.rb
@@ -13,6 +13,7 @@ module Pismo
 
     MONTHS_REGEX = %r{(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec|January|February|March|April|May|June|July|August|September|October|November|December)\.?}i
     DATETIME_REGEXEN = [
+      /#{MONTHS_REGEX}\b\.\s+\d{2}\,\s+\d{4}\s+\d{2}\:\d{2}\s+(a|p)\.m\./i, #Jul. 25, 2012 10:46 a.m.
       /#{MONTHS_REGEX}\b\s+\d+\D{1,10}\d{4}/i,
       /(on\s+)?\d+\s+#{MONTHS_REGEX}\s+\D{0,10}\d+/i,
       /(on[^\d+]{1,10})\d+(th|st|rd)?.{1,10}#{MONTHS_REGEX}\b[^\d]{1,10}\d+/i,

--- a/test/corpus/metadata_expected.yaml
+++ b/test/corpus/metadata_expected.yaml
@@ -87,5 +87,5 @@
   :datetime: 2010-02-17 12:00:00 +00:00
 :thegoodbookblog:
   :title: Signs Of Life
-  :datetime: 2012-07-25 12:00:00 +00:00
+  :datetime: 2012-07-25 10:46:00 +00:00
   :tags: [Church Life, Marriage and Family, Ministry and Leadership]


### PR DESCRIPTION
Year, hour and minutes was missing on datetime detection in this
format: "Jul. 25, 2012 10:46 a.m". Because of this, Chronic was
inferring year, hour and minutes wrongly.
