### PR TITLE
fixing detection of multiple feeds of the same type

### DIFF
--- a/lib/pismo.rb
+++ b/lib/pismo.rb
@@ -86,12 +86,16 @@ class Nokogiri::HTML::Document
               end
             end
           elsif query.is_a?(Array)
-            query.last.call( self.search(query.first).first )
+            self.search(query.first).map do |node|
+              query.last.call(node)
+            end
           end
         rescue
           nil
         end
-        results << Pismo.normalize_entities(result.strip) if result
+        Array(result).compact.each do |r|
+          results << Pismo.normalize_entities(r.strip)
+        end
       end
     end.compact
   end

--- a/lib/pismo/internal_attributes.rb
+++ b/lib/pismo/internal_attributes.rb
@@ -28,8 +28,8 @@ module Pismo
     TITLE_SEPARATORS_REGEX = /\s(\p{Pd}|\:|\p{Pf}|\||\:\:|\.)\s/
 
     FEED_MATCHES = [
-      ['link[@type="application/rss+xml"]',  lambda { |el| el.attr('href') }],
-      ['link[@type="application/atom+xml"]', lambda { |el| el.attr('href') }]
+      ['link[@type="application/rss+xml"][@rel="alternate"]',  lambda { |el| el.attr('href') }],
+      ['link[@type="application/atom+xml"][@rel="alternate"]', lambda { |el| el.attr('href') }]
     ]
 
     FAVICON_MATCHES = [

--- a/test/feed_test.rb
+++ b/test/feed_test.rb
@@ -1,0 +1,24 @@
+require 'helper'
+
+class FeedTest < Test::Unit::TestCase
+
+  context "Pismo::InternalAttributes" do
+
+    setup do
+      @doc = File.read 'test/corpus/factor.html'
+    end
+
+    should "find feeds" do
+      pismo = Pismo::Document.new @doc
+      expected = [
+        'http://factor-language.blogspot.com/feeds/posts/default?alt=rss',
+        'http://factor-language.blogspot.com/feeds/posts/default',
+        'http://factor-language.blogspot.com/feeds/657377910223810792/comments/default'
+      ]
+
+      assert_equal expected, pismo.feeds
+    end
+
+  end
+
+end


### PR DESCRIPTION
if there are multiple feeds of the same type on one page:

```
<link rel="alternate" type="application/atom+xml" title="feed one - atom" href="http://example.com/feed.atom" />
<link rel="alternate" type="application/atom+xml" title="feed two - atom" href="http://example.com/feed-two.atom" />
<link rel="alternate" type="application/rss+xml" title="feed one - rss" href="http://example.com/feed.atom" />
```

only the first and the last would be returned by the `feeds` method.

this is obviously suboptimal and this pr fixes it.
